### PR TITLE
minor bug fixes - plugin interface and username/password issues

### DIFF
--- a/basefunctions.cfm
+++ b/basefunctions.cfm
@@ -20,7 +20,7 @@
 	<cfif StructKeyExists(Request, "migrationSQLFile")>
 		<cffile action="append" file="#Request.migrationSQLFile#" output="#arguments.sql#;" addNewLine="yes" fixNewLine="yes">
 	</cfif>
-	<cfquery datasource="#application.wheels.dataSourceName#" username="#application.wheels.dataSourceUserName#" password="#application.wheels.dataSourcePassword#">
+	<cfquery datasource="#application.wheels.dataSourceName#">
 	#PreserveSingleQuotes(arguments.sql)#
 	</cfquery>
 </cffunction>

--- a/index.cfm
+++ b/index.cfm
@@ -4,19 +4,20 @@
 <cfset dbmigrateMeta.version = "1.3.3">
 
 <cfinclude template="basefunctions.cfm">
-
+<!--- explicitly set url to avoid odd issue when ses urls enabled --->
+<cfset selfUrl = "?controller=wheels&action=wheels&view=plugins&name=dbmigrate">
 <cfif isDefined("Form.version")>
 	<cfset flashInsert(dbmigrateFeedback=application.wheels.plugins.dbmigrate.migrateTo(Form.version))>
-	<cfset redirectTo(controller="wheels", action="wheels", params="view=plugins&name=dbmigrate")>
+	<cflocation url="#selfUrl#" addtoken="false">
 <cfelseif isDefined("Form.migrationName")>
 	<cfparam name="Form.templateName" default="">
 	<cfparam name="Form.migrationPrefix" default="">
 	<cfset flashInsert(dbmigrateFeedback2=application.wheels.plugins.dbmigrate.createMigration(Form.migrationName,Form.templateName,Form.migrationPrefix))>
-	<cfset redirectTo(controller="wheels", action="wheels", params="view=plugins&name=dbmigrate")>
+	<cflocation url="#selfUrl#" addtoken="false">
 <cfelseif isDefined("url.migrateToVersion") And Len(Trim(url.migrateToVersion)) GT 0 And IsNumeric(url.migrateToVersion)>
   <cfif isDefined("url.password") And Trim(url.password) EQ application.wheels.reloadPassword>
   	<cfset flashInsert(dbmigrateFeedback=application.wheels.plugins.dbmigrate.migrateTo(url.migrateToVersion))>
-  	<cfset redirectTo(controller="wheels", action="wheels", params="view=plugins&name=dbmigrate")>
+  	<cflocation url="#selfUrl#" addtoken="false">
   </cfif>
 </cfif>
 


### PR DESCRIPTION
I'm not sure if you will actually want to merge these changes in, but i thought i should at least create a pull request so you can see the changes (which im sure there are better ways of implementing).

The issue with username/pass on cfqueries was as follows:

"Datasource xxx verification failed.
The root cause was that: java.sql.SQLException: Usernames and
Passwords for all the database tags within the cftransaction tag must
be the same. " 

I checked all cfquery tags to see if perhaps one of them was missing this info (even if you dont use the config values it is still an issue), however i couldn't find any instances of this, so quick fix was to just disable it entirely and rely on cfadmin controlling this access.

The other issue relates to using the dbmigrate plugin view pages... having ses urls enabled/urlrewriting was resulting in the urls being generated incorrectly...
